### PR TITLE
update stable tarball hash

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,10 +12,10 @@ source:
   # If we want reproducible URLs, we can use
   # commits on the stable branch, which won't get autotick PRs
   url: https://download.libsodium.org/libsodium/releases/libsodium-${{ version }}-stable.tar.gz
-  sha256: 2c7c0083a3d4151634b4237139a6bc216ae3c5cd95ad9c04fc16551021e28a0b
+  sha256: 0e50702dd91b0901aef3d645e7cc56e9e9a07f80bf70758d4fb96fe459510e52
 
 build:
-  number: 1
+  number: 2
   script: build
 
 requirements:


### PR DESCRIPTION
closes #26 

not sure if this is going to be annoying or not, but it's already caused a failure to publish

alternative: point to stable _branch_, and add test to verify that package version matches installed version. That approach will never get version bump PRs.